### PR TITLE
Use 'with' and use specific 'utf-8' encoding

### DIFF
--- a/src/name-constraints-encoder.py
+++ b/src/name-constraints-encoder.py
@@ -92,9 +92,8 @@ def create_api_passthrough_json(encoded, output_file_name="api_passthrough_confi
     data_json["Extensions"]["CustomExtensions"][0]["Value"] = encoded.decode("utf-8")
     data_json["Extensions"]["CustomExtensions"][0]["Critical"] = True
 
-    file = open(output_file_name, "w")
-    json.dump(data_json, file, indent=4)  # include indent for pretty-print
-    file.close()
+    with open(output_file_name, "w", encoding="utf-8") as file:
+        json.dump(data_json, file, indent=4) # include indent for pretty-print
 
     logging.info(f"API Passthrough File Created: {output_file_name}")
 


### PR DESCRIPTION
Updated to use 'with open()' instead of open() and close(). Also specified 'utf-8' encoding explicitly to avoid using system default.

References:
https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files